### PR TITLE
fix: typo in operator names

### DIFF
--- a/evolvekit/operators/Ga/crossover/real/ArithmeticalCrossover.py
+++ b/evolvekit/operators/Ga/crossover/real/ArithmeticalCrossover.py
@@ -9,7 +9,7 @@ from evolvekit.core.Ga.operators.GaOperatorArgs import GaOperatorArgs
 from evolvekit.core.Ga.GaIndividual import GaIndividual
 
 
-class ArthmeticalCrossover(GaOperator):
+class ArithmeticalCrossover(GaOperator):
     def __init__(self, k: int = 2):
         """Initializes ArthmeticalCrossover operator
 

--- a/evolvekit/operators/Ga/mutation/real/UniformMutation.py
+++ b/evolvekit/operators/Ga/mutation/real/UniformMutation.py
@@ -8,7 +8,7 @@ from evolvekit.core.Ga.operators.GaOperator import GaOperator
 from evolvekit.core.Ga.operators.GaOperatorArgs import GaOperatorArgs
 
 
-class UniformMutaion(GaOperator):
+class UniformMutation(GaOperator):
     def __init__(self, p_um: float = 0.1):
         """Initializes uniform mutation operator for real-valued
         chromosomes.


### PR DESCRIPTION
This pull request addresses issue #24 

Fixes the typos in operator names. 